### PR TITLE
PeptideGraph will no longer create repeated nodes.

### DIFF
--- a/components/graphs/peptideGraph/PeptideGraph.tsx
+++ b/components/graphs/peptideGraph/PeptideGraph.tsx
@@ -55,13 +55,15 @@ const PeptideGraph: React.FC<Props> = ({ peptide, width, height }) => {
 
     Object.entries(peptide.metadata).forEach(([relationship, metadataValues]) => {
       metadataValues.forEach((metadataValue) => {
-        nodes.push({
-          id: metadataValue,
-          label: metadataValue,
-          title: metadataValue,
-          color: nodeColorsByRelationship[relationship as RelationshipLabel],
-          group: relationship
-        });
+        if (!nodes.some((node) => node.id === metadataValue)) {
+          nodes.push({
+            id: metadataValue,
+            label: metadataValue,
+            title: metadataValue,
+            color: nodeColorsByRelationship[relationship as RelationshipLabel],
+            group: relationship
+          });
+        }
 
         edges.push({
           id: `${relationship}-${metadataValue}`,


### PR DESCRIPTION
* Fixed a bug where the peptide page of certain peptides would crash because the graph would try to render multiple nodes with the same ID.